### PR TITLE
Additional options for handling errors

### DIFF
--- a/geebam.py
+++ b/geebam.py
@@ -55,7 +55,8 @@ def upload_from_parser(args):
            nodata_value=args.nodata,
            bucket_name=args.bucket,
            band_names=args.bands,
-           signal_if_error=args.upload_catch_error)
+           signal_if_error=args.upload_catch_error,
+           tolerate_assets_already_exist=args.tolerate_assets_already_exist)
 
 def _comma_separated_strings(string):
     """Parses an input consisting of comma-separated strings.
@@ -103,6 +104,11 @@ def main(args=None):
         '--upload-catch-error',
         action='store_true',
         help='Return exit code 1 when upload catches an error')
+    optional_named.add_argument(
+        '-a',
+        '--tolerate-assets-already-exist',
+        action='store_true',
+        help='Return exit 0 when assets already exist')
 
     parser_upload.set_defaults(func=upload_from_parser)
 

--- a/geebam.py
+++ b/geebam.py
@@ -22,6 +22,7 @@ __license__ = "Apache 2.0"
 import argparse
 import logging
 import os
+
 import ee
 
 from gee_asset_manager.batch_remover import delete
@@ -39,7 +40,7 @@ def cancel_all_running_tasks():
 
 def cancel_all_running_tasks_from_parser(args):
     cancel_all_running_tasks()
-    
+
 
 def delete_collection_from_parser(args):
     delete(args.id)
@@ -53,19 +54,20 @@ def upload_from_parser(args):
            multipart_upload=args.large,
            nodata_value=args.nodata,
            bucket_name=args.bucket,
-           band_names=args.bands)
+           band_names=args.bands,
+           signal_if_error=args.upload_catch_error)
 
 def _comma_separated_strings(string):
-  """Parses an input consisting of comma-separated strings.
-     Slightly modified version of: https://pypkg.com/pypi/earthengine-api/f/ee/cli/commands.py
-  """
-  error_msg = 'Argument should be a comma-separated list of alphanumeric strings (no spaces or other' \
-              'special characters): {}'
-  values = string.split(',')
-  for name in values:
-      if not name.isalnum():
-          raise argparse.ArgumentTypeError(error_msg.format(string))
-  return values
+    """Parses an input consisting of comma-separated strings.
+       Slightly modified version of: https://pypkg.com/pypi/earthengine-api/f/ee/cli/commands.py
+    """
+    error_msg = 'Argument should be a comma-separated list of alphanumeric strings (no spaces or other' \
+                'special characters): {}'
+    values = string.split(',')
+    for name in values:
+        if not name.isalnum():
+            raise argparse.ArgumentTypeError(error_msg.format(string))
+    return values
 
 
 
@@ -96,6 +98,11 @@ def main(args=None):
     optional_named.add_argument('-s', '--service-account', help='Google Earth Engine service account.')
     optional_named.add_argument('-k', '--private-key', help='Google Earth Engine private key file.')
     optional_named.add_argument('-b', '--bucket', help='Google Cloud Storage bucket name.')
+    optional_named.add_argument(
+        '-e',
+        '--upload-catch-error',
+        action='store_true',
+        help='Return exit code 1 when upload catches an error')
 
     parser_upload.set_defaults(func=upload_from_parser)
 


### PR DESCRIPTION
Hey,

We're currently using your gee_asset_manager in a process that automatically ingests files into GEE and noticed a couple of things, that didn't really fit into our expected behavior:
1. It returns a non-zero code if the target collection already has all of the images uploaded. In our case, we treat it as a success, so we return the 0 code.
2. It returns a 0 code if the provided service Google service account doesn't have permissions to the target storage bucket. This is a clear error and should be treated as such.

We didn't want to alter the origin behavior, so we added a couple of options to control it. May be, these changes will be of use to somebody else.